### PR TITLE
Updated clearing of micromamba dir before micromamba initialization

### DIFF
--- a/bash/pixi/pixi-mamba.sh
+++ b/bash/pixi/pixi-mamba.sh
@@ -6,15 +6,20 @@ curl -fsSL https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/pixi-set
 pixi global install $(curl -fsSL https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/global_packages.txt | tr '\n' ' ')
 
 # install R and Python libraries currently via micromamba although later pixi will also support installing them in `global` as libraries without `bin`
+# NOTE: This is assuming a first-time run
+if [ -n ${HOME}/micromamba/envs/etc ]; then
+    rm -rf ${HOME}/micromamba/etc
+fi
 micromamba config prepend channels nodefaults 
 micromamba config prepend channels bioconda
 micromamba config prepend channels conda-forge
 micromamba config prepend channels dnachun
 micromamba shell init --shell=bash ${HOME}/micromamba
-# NOTE: This is assuming a first-time run
+
 if [ -n ${HOME}/micromamba/envs/etc ]; then
     rm -rf ${HOME}/micromamba/etc
 fi
+
 
 curl -O https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/r.yml && micromamba env create --yes --file r.yml && rm -f r.yml
 curl -O https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/python.yml && micromamba env create --yes --file python.yml && rm -f python.yml


### PR DESCRIPTION
To explain the situation:

`micromamba` will throw an error if the `micromamba` folder is populated BEFORE `micromamba config prepend channels nodefaults`, AND BEFORE `micromamba env create --yes --file r.yml`. Putting the two cases in the code lets `micromamba `install just fine.