### PR TITLE
Updated to check if file/directories exist

### DIFF
--- a/bash/pixi/init.sh
+++ b/bash/pixi/init.sh
@@ -3,26 +3,35 @@ set -o errexit -o xtrace
 
 # Use sitecustomize.py so that specific Python packages can see python_libs packages
 if [ -d "/mnt/efs" ]; then
-   mkdir -p ${HOME}/.local/lib/python3.12/site-packages
-   tee ${HOME}/.local/lib/python3.12/site-packages/sitecustomize.py << EOF
+   if [[ ! -f ${HOME}/.local/lib/python3.12/site-packages/sitecustomize.py ]]; then
+      mkdir -p ${HOME}/.local/lib/python3.12/site-packages
+      tee ${HOME}/.local/lib/python3.12/site-packages/sitecustomize.py << EOF
 import sys
 sys.path[0:0] = [
    "/mnt/efs/shared/.pixi/envs/python/lib/python3.12/site-packages"
 ]
 EOF
-   echo ".libPaths('/mnt/efs/shared/.pixi/envs/r-base/lib/R/library')" >> ${HOME}/.Rprofile
+   fi
+   if [[ ! -f ${HOME}/.Rprofile ]]; then
+      echo ".libPaths('/mnt/efs/shared/.pixi/envs/r-base/lib/R/library')" >> ${HOME}/.Rprofile
+   fi
 fi
 
 # Use Rprofile.site so that only pixi-installed R can see r-base packages
-echo ".libPaths('${HOME}/.pixi/envs/r-base/lib/R/library')" >> ${HOME}/.pixi/envs/python/lib/R/etc/Rprofile.site
+if [[ ! -f ${HOME}/.pixi/envs/python/lib/R/etc/Rprofile.site ]]; then
+   echo ".libPaths('${HOME}/.pixi/envs/r-base/lib/R/library')" >> ${HOME}/.pixi/envs/python/lib/R/etc/Rprofile.site
+fi
 
 # Create config files for rstudio
-mkdir -p ${HOME}/.config/rstudio
-tee ${HOME}/.config/rstudio/database.conf << EOF
+if [[ ! -f ${HOME}/.config/rstudio/database.conf ]]; then
+   mkdir -p ${HOME}/.config/rstudio
+   tee ${HOME}/.config/rstudio/database.conf << EOF
 directory=${HOME}/.local/var/lib/rstudio-server
 EOF
+fi
 
-tee ${HOME}/.config/rstudio/rserver.conf << EOF
+if [[ ! -f ${HOME}/.config/rstudio/rserver.conf ]]; then
+   tee ${HOME}/.config/rstudio/rserver.conf << EOF
 rsession-which-r=${HOME}/.pixi/envs/r-base/bin/R
 auth-none=1
 database-config-file=${HOME}/.config/rstudio/database.conf
@@ -30,32 +39,45 @@ server-daemonize=0
 server-data-dir=${HOME}/.local/var/run/rstudio-server
 server-user=${USER}
 EOF
+fi
 
 # Register Juypter kernels
-find ${HOME}/.pixi/envs/python/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
-   xargs -I % jupyter-kernelspec install --log-level=50 --user %
-find ${HOME}/.pixi/envs/r-base/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
-   xargs -I % jupyter-kernelspec install --log-level=50 --user %
-# ark --install
+if [[ -d ${HOME}/.pixi/envs/python/share/jupyter/kernels/ ]]; then
+   find ${HOME}/.pixi/envs/python/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
+      xargs -I % jupyter-kernelspec install --log-level=50 --user %
+   find ${HOME}/.pixi/envs/r-base/share/jupyter/kernels/ -maxdepth 1 -mindepth 1 -type d | \
+      xargs -I % jupyter-kernelspec install --log-level=50 --user %
+   # ark --install
+fi
 
 # Jupyter configurations
-mkdir -p $HOME/.jupyter && \
-curl -s -o $HOME/.jupyter/jupyter_lab_config.py https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/jupyter/jupyter_lab_config.py && \
-curl -s -o $HOME/.jupyter/jupyter_server_config.py https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/jupyter/jupyter_server_config.py
+if [[ ! -f $HOME/.jupyter/jupyter_lab_config.py ]] && [[ ! -f $HOME/.jupyter/jupyter_server_config.py ]]; then
+   mkdir -p $HOME/.jupyter && \
+   curl -s -o $HOME/.jupyter/jupyter_lab_config.py https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/jupyter/jupyter_lab_config.py && \
+   curl -s -o $HOME/.jupyter/jupyter_server_config.py https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/jupyter/jupyter_server_config.py
+fi
 
 # VSCode configurations
-mkdir -p ${HOME}/.config/code-server
-curl -s -o $HOME/.config/code-server/config.yaml https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/vscode/config.yaml
-mkdir -p ${HOME}/.local/share/code-server/User
-curl -s -o $HOME/.local/share/code-server/User/settings.json https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/vscode/settings.json
+if [[ ! -f $HOME/.config/code-server/config.yaml ]] && [[ ! -f $HOME/.local/share/code-server/User/settings.json ]]; then
+   mkdir -p ${HOME}/.config/code-server
+   curl -s -o $HOME/.config/code-server/config.yaml https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/vscode/config.yaml
+   mkdir -p ${HOME}/.local/share/code-server/User
+   curl -s -o $HOME/.local/share/code-server/User/settings.json https://raw.githubusercontent.com/gaow/misc/master/bash/pixi/configs/vscode/settings.json
+fi
 
-code-server --install-extension ms-python.python
-code-server --install-extension ms-toolsai.jupyter
-code-server --install-extension reditorsupport.r
-code-server --install-extension rdebugger.r-debugger
-code-server --install-extension ionutvmi.path-autocomplete
-code-server --install-extension usernamehw.errorlens
+if ! code-server -v <the_command> 2>&1 >/dev/null; then
+   echo "WARNING: code-server is not installed."
+else
+   code-server --install-extension ms-python.python
+   code-server --install-extension ms-toolsai.jupyter
+   code-server --install-extension reditorsupport.r
+   code-server --install-extension rdebugger.r-debugger
+   code-server --install-extension ionutvmi.path-autocomplete
+   code-server --install-extension usernamehw.errorlens
+fi
 
 # Temporary fix to run post-link scripts
-find ${HOME}/.pixi/envs/r-base/bin -name '*bioconductor-*-post-link.sh' | \
-  xargs -I % bash -c "PREFIX=${HOME}/.pixi/envs/r-base PATH=${HOME}/.pixi/envs/r-base/bin:${PATH} %"
+if [[ -d ${HOME}/.pixi/envs/r-base/bin ]]; then
+   find ${HOME}/.pixi/envs/r-base/bin -name '*bioconductor-*-post-link.sh' | \
+   xargs -I % bash -c "PREFIX=${HOME}/.pixi/envs/r-base PATH=${HOME}/.pixi/envs/r-base/bin:${PATH} %"
+fi


### PR DESCRIPTION
This change is to allow for `init.sh` to be run at the start of the VM for interactive jobs. As admin and modes where the symlinks do exist are expected to run the full `pixi-setup` script, it will run `init.sh` already.

The changes to this script are more for `oem-packages`, where there are not symlinks and therefore no config files are saved in the VM. Running `init.sh` at the beginning of this mode should allow for config files to be created, as well as the ability to use shared packages properly.